### PR TITLE
enable opt out of user_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ No modules.
 | <a name="input_enable_secondary_ebs_volume"></a> [enable\_secondary\_ebs\_volume](#input\_enable\_secondary\_ebs\_volume) | Enable the creation of a secondary EBS volume | `bool` | `false` | no |
 | <a name="input_enable_sqs_events_on_bastion_login"></a> [enable\_sqs\_events\_on\_bastion\_login](#input\_enable\_sqs\_events\_on\_bastion\_login) | If true, generates an SQS event whenever an object is created in the Session Logs S3 bucket, which happens whenever someone logs in to the Bastion. | `bool` | `false` | no |
 | <a name="input_eni_attachment_config"></a> [eni\_attachment\_config](#input\_eni\_attachment\_config) | Optional list of enis to attach to instance | <pre>list(object({<br>    network_interface_id = string<br>    device_index         = string<br>  }))</pre> | `null` | no |
+| <a name="input_include_user_data"></a> [include\_user\_data](#input\_include\_user\_data) | A flag to include user data in the instance | `bool` | `true` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type to use for Bastion | `string` | `"m5.large"` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS Key ARN to use for encryption | `string` | n/a | yes |
 | <a name="input_linux_shell_profile"></a> [linux\_shell\_profile](#input\_linux\_shell\_profile) | The ShellProfile to use for linux based machines. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_instance" "application" {
   ami                         = var.ami_id != "" ? var.ami_id : data.aws_ami.from_filter[0].id
   instance_type               = var.instance_type
   vpc_security_group_ids      = length(local.security_group_configs) > 0 ? aws_security_group.sg[*].id : var.security_group_ids
-  user_data                   = data.cloudinit_config.config.rendered
+  user_data                   = var.include_user_data ? data.cloudinit_config.config.rendered : null
   iam_instance_profile        = local.role_name == "" ? null : aws_iam_instance_profile.bastion_ssm_profile.name
   ebs_optimized               = true
   associate_public_ip_address = var.assign_public_ip

--- a/variables.tf
+++ b/variables.tf
@@ -268,3 +268,9 @@ variable "enable_bastion_terraform_permissions" {
   type        = bool
   default     = false
 }
+
+variable "include_user_data" {
+  description = "A flag to include user data in the instance"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
closes #110 

This enables opt-out of the user_data baked into this module in support of users who satisfy dependencies via a different mechanism.