### PR TITLE
feat: add lifecyle to ebs volume

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,10 @@ resource "aws_ebs_volume" "bastion_secondary_ebs_volume" {
   size              = var.bastion_secondary_ebs_volume_size
   encrypted         = true
   tags              = var.tags
+
+  lifecycle {
+    ignore_changes = [availability_zone]
+  }
 }
 
 resource "aws_volume_attachment" "ebs_attachment" {


### PR DESCRIPTION
Adding a lifecycle policy to the ebs volume, this allows for an ebs volume to be re-used even after the instance has been destroyed or re-created