### PR TITLE
fix: replace user_data input with user_data_base64

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "application" {
   ami                         = var.ami_id != "" ? var.ami_id : data.aws_ami.from_filter[0].id
   instance_type               = var.instance_type
   vpc_security_group_ids      = length(local.security_group_configs) > 0 ? aws_security_group.sg[*].id : var.security_group_ids
-  user_data                   = var.user_data_override != null ? var.user_data_override : data.cloudinit_config.config.rendered
+  user_data_base64            = var.user_data_override != null ? base64gzip(var.user_data_override) : data.cloudinit_config.config.rendered
   iam_instance_profile        = local.role_name == "" ? null : aws_iam_instance_profile.bastion_ssm_profile.name
   ebs_optimized               = true
   associate_public_ip_address = var.assign_public_ip


### PR DESCRIPTION
When a user_data override becomes too large it will result with this error when trying to apply
`[Terraform Launch Script too long for AWS: expected length of user_data to be in the range (1 - 16384), got #!/bin/bash]`

Following [this stack overflow](https://stackoverflow.com/questions/73394471/terraform-launch-script-too-long-for-aws-expected-length-of-user-data-to-be-in), changing the input from `user_data` to `user_data_base64` and then using `base64gzip` can get around the 16 KB size limit.